### PR TITLE
Setting up code for Heroku deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Project 2 Starter",
   "main": "server.js",
   "scripts": {
-    "start": "nodemon server.js",
+    "start": "node server.js",
+    "watch": "nodemon server.js",
     "lint": "eslint --quiet .",
     "fix": "eslint --fix .",
     "test": "npm run lint && cross-env NODE_ENV=test mocha -u tdd --reporter spec --exit"

--- a/routes/Procfile
+++ b/routes/Procfile
@@ -1,0 +1,1 @@
+web: nodemon server.js

--- a/server.js
+++ b/server.js
@@ -25,11 +25,12 @@ app.set("view engine", "handlebars");
 require("./routes/apiRoutes")(app);
 // require("./routes/htmlRoutes")(app);
 
-var syncOptions = { force: true };
+var syncOptions = { force: false };
 
 // If running a test, set syncOptions.force to true
 // clearing the `testdb`
-if (process.env.NODE_ENV === "test") {
+if (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development") {
+  console.log("Detected DEV/TEST env, force syncing database")
   syncOptions.force = true;
 }
 


### PR DESCRIPTION
#### Code can now use the below env variables:

> NODE_ENV : development/test/production
> JAWSDB_URL: Production DB URL

#### Also changed start script to `node` instead of `nodemon`

#### Default syncOptions changed back to `false`. If env variable of `test` or `development` is used, syncOptions will have a value `true`
