### PR TITLE
Linking between Order History and detail pages

### DIFF
--- a/views/customerOrderHistory.handlebars
+++ b/views/customerOrderHistory.handlebars
@@ -14,7 +14,7 @@
         <td class="orderColumn orderStatus">{{order_status}}</td>
         <td class="orderColumn orderItemCount">{{order_item_count}}</td>
         <td class="orderColumn orderDate">{{createdAt}}</td>
-        <td class="orderColumn orderDetailsLink" id={{id}}><a href="#">Details</a></td>
+        <td class="orderColumn orderDetailsLink" id={{id}}><a href="/api/orders/{{id}}">Details</a></td>
     </tr>
     {{/each}}
     </tbody>

--- a/views/supplierOrderHistory.handlebars
+++ b/views/supplierOrderHistory.handlebars
@@ -14,7 +14,7 @@
         <td class="orderColumn orderStatus">{{order_status}}</td>
         <td class="orderColumn orderItemCount">{{order_item_count}}</td>
         <td class="orderColumn orderDate">{{createdAt}}</td>
-        <td class="orderColumn orderDetailsLink" id={{id}}><a href="#">Details</a></td>
+        <td class="orderColumn orderDetailsLink" id={{id}}><a href="/api/orders/{{id}}">Details</a></td>
     </tr>
     {{/each}}
     </tbody>


### PR DESCRIPTION
This PR allows clicking on "Details" link in Customer Order History or Supplier Order History and shows the order details.