### PR TITLE
Enable "Save Changes" button only if a new Order State has been chosen

### DIFF
--- a/public/js/supplierOrderHistory.js
+++ b/public/js/supplierOrderHistory.js
@@ -1,4 +1,5 @@
 $(document).ready(function() {
+  $("#save-changes").prop('disabled', true);
   $(".dropdown-menu a").click(function() {
     $(this)
       .parents(".dropdown")
@@ -8,7 +9,11 @@ $(document).ready(function() {
       .parents(".dropdown")
       .find(".btn")
       .val($(this).data("value"));
-  });
+    $("#save-changes").prop('disabled', false);
+    $("#save-changes").removeClass('btn-secondary');
+    $("#save-changes").addClass('btn-success');
+
+    });
 
   $("#save-changes").on("click", function (event) {
     event.stopImmediatePropagation();

--- a/views/supplierOrderHistory.handlebars
+++ b/views/supplierOrderHistory.handlebars
@@ -38,7 +38,7 @@
             </table>
 
             <div class="buttons mt-3">
-                <button type="submit" class="btn btn-primary mr-3" id="save-changes">Save Changes</button>
+                <button type="submit" class="btn btn-secondary mr-3" id="save-changes">Save Changes</button>
                 <span class="dropdown">
                     <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Prior to this fix:
`SAVE CHANGES` button could be clicked without choosing a new Order Status. This caused order status from getting updated as Blanks.

With this fix:
The `SAVE CHANGES` button would be disabled till a new Order Status is chosen