### PR TITLE
Removing "See All Orders" button in Order Detail Page

### DIFF
--- a/views/orderDetail.handlebars
+++ b/views/orderDetail.handlebars
@@ -49,7 +49,6 @@
                 {{/each}}
 
             </table>
-            <a href="" class="btn btn-primary mt-3" id="order-btn">See All Orders</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The navigation from Order Detail back to Order List is available through Navbar. Hence removing this extra button